### PR TITLE
feat: skill editing and refactor store winrate calc

### DIFF
--- a/src/components/BoardCardElement.tsx
+++ b/src/components/BoardCardElement.tsx
@@ -3,7 +3,10 @@ import React, { useState } from "react";
 import { cn } from "@/lib/utils";
 import FramedCardOrSkill from "./FramedCardOrSkill";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./Tooltip";
-import { useSimulatorStore, useEditingCardIndex } from "@/lib/simulatorStore";
+import {
+  useSimulatorStore,
+  useEditingCardLocation,
+} from "@/lib/simulatorStore";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { CARD_HEIGHT, ENEMY_PLAYER_IDX } from "@/lib/constants";
@@ -58,7 +61,7 @@ export function BoardCardElement({
   boardCardIdx: number;
 }) {
   const simulatorStoreActions = useSimulatorStore((state) => state.actions);
-  const editingCardIndex = useEditingCardIndex();
+  const editingCardLocation = useEditingCardLocation();
 
   const [cardConfig, setCardConfig] = useState<
     Partial<{
@@ -155,7 +158,10 @@ export function BoardCardElement({
             {/* Settings button */}
             {!isSorting && (
               <Dialog
-                open={editingCardIndex === boardCardIdx}
+                open={
+                  editingCardLocation?.cardIdx === boardCardIdx &&
+                  editingCardLocation?.playerIdx === playerIdx
+                }
                 onOpenChange={(value) => {
                   if (!value) {
                     // Save changes when closing the dialog
@@ -180,11 +186,20 @@ export function BoardCardElement({
                       playerIdx === ENEMY_PLAYER_IDX,
                     );
                   }
-                  simulatorStoreActions.setEditingCardIndex(
-                    value ? boardCardIdx : null,
+                  simulatorStoreActions.setEditingCardLocation(
+                    value
+                      ? {
+                          cardIdx: boardCardIdx,
+                          playerIdx,
+                          location: "board",
+                        }
+                      : null,
                   );
                 }}
-                defaultOpen={editingCardIndex === boardCardIdx}
+                defaultOpen={
+                  editingCardLocation?.cardIdx === boardCardIdx &&
+                  editingCardLocation?.playerIdx === playerIdx
+                }
               >
                 <DialogTrigger asChild>
                   <div className="tooltip absolute top-0.5 right-0.5 z-10">
@@ -224,9 +239,11 @@ export function BoardCardElement({
                               value,
                               playerIdx === ENEMY_PLAYER_IDX,
                             );
-                            simulatorStoreActions.setEditingCardIndex(
-                              boardCardIdx,
-                            );
+                            simulatorStoreActions.setEditingCardLocation({
+                              cardIdx: boardCardIdx,
+                              playerIdx,
+                              location: "board",
+                            });
                           }}
                         >
                           <SelectTrigger>
@@ -264,9 +281,11 @@ export function BoardCardElement({
                               value,
                               playerIdx === ENEMY_PLAYER_IDX,
                             );
-                            simulatorStoreActions.setEditingCardIndex(
-                              boardCardIdx,
-                            );
+                            simulatorStoreActions.setEditingCardLocation({
+                              cardIdx: boardCardIdx,
+                              playerIdx,
+                              location: "board",
+                            });
                           }}
                         >
                           <SelectTrigger>

--- a/src/components/BoardSkillElement.tsx
+++ b/src/components/BoardSkillElement.tsx
@@ -5,11 +5,33 @@ import React from "react";
 import FramedCardOrSkill from "./FramedCardOrSkill";
 import CardTooltip from "./CardTooltip";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./Tooltip";
-import { useSimulatorStore } from "@/lib/simulatorStore";
+import {
+  useSimulatorStore,
+  useEditingCardLocation,
+} from "@/lib/simulatorStore";
 import { PLAYER_PLAYER_IDX, ENEMY_PLAYER_IDX } from "@/lib/constants";
 import { Button } from "./ui/button";
 import { X } from "lucide-react";
 import { CardType } from "@/types/cardTypes";
+import { Tier } from "@/types/shared";
+import { Settings } from "lucide-react";
+import { CardLocationID } from "@/engine/engine2/engine2";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
 
 export function BoardSkillElement({
   boardSkill,
@@ -23,9 +45,16 @@ export function BoardSkillElement({
   boardCardID: number;
 }) {
   const simulatorStoreActions = useSimulatorStore((state) => state.actions);
+  const editingCardLocation = useEditingCardLocation();
 
   const card = boardSkill.card;
   const IMAGE_SIZE = 60;
+
+  const cardLocation: CardLocationID = {
+    playerIdx: playerID,
+    cardIdx: boardCardID,
+    location: "board",
+  };
 
   return (
     <Tooltip placement="bottom">
@@ -43,6 +72,74 @@ export function BoardSkillElement({
             skillSize={IMAGE_SIZE}
             tier={boardSkill.tier}
           />
+          {/* Settings button */}
+          <Dialog
+            open={
+              editingCardLocation?.location === "board" &&
+              editingCardLocation?.playerIdx === playerID &&
+              editingCardLocation?.cardIdx === boardCardID
+            }
+            onOpenChange={(value) => {
+              simulatorStoreActions.setEditingCardLocation(
+                value ? cardLocation : null,
+              );
+            }}
+            defaultOpen={
+              editingCardLocation?.location === "board" &&
+              editingCardLocation?.playerIdx === playerID &&
+              editingCardLocation?.cardIdx === boardCardID
+            }
+          >
+            <DialogTrigger asChild>
+              <div className="tooltip absolute top-0.5 right-0.5 z-10">
+                <Button
+                  variant="secondary"
+                  size="icon"
+                  className="h-6 w-6 p-0 hover:cursor-pointer"
+                  onClick={() => {
+                    simulatorStoreActions.setAutoScroll(false);
+                  }}
+                >
+                  <Settings className="h-4 w-4" />
+                </Button>
+              </div>
+            </DialogTrigger>
+            <DialogContent className="max-h-[90vh] overflow-y-auto">
+              <DialogHeader>
+                <DialogTitle>
+                  Edit {playerID === ENEMY_PLAYER_IDX ? "Enemy" : "Player"}{" "}
+                  Skill
+                </DialogTitle>
+              </DialogHeader>
+              <DialogDescription>Edit the tier of the skill.</DialogDescription>
+              <div className="flex flex-col gap-2">
+                {/* Tier Select */}
+                <Label htmlFor="tier">Tier</Label>
+                <div className="flex gap-2">
+                  <Select
+                    onValueChange={(value: Tier) => {
+                      simulatorStoreActions.setSkillTier(
+                        boardCardID,
+                        value,
+                        playerID === ENEMY_PLAYER_IDX,
+                      );
+                    }}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder={boardSkill.tier} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {Object.keys(card.Tiers ?? {}).map((tier) => (
+                        <SelectItem key={tier} value={tier}>
+                          {tier}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            </DialogContent>
+          </Dialog>
           {/* Remove button */}
           {(playerID === PLAYER_PLAYER_IDX ||
             playerID === ENEMY_PLAYER_IDX) && (

--- a/src/components/BoardSkillElement.tsx
+++ b/src/components/BoardSkillElement.tsx
@@ -118,8 +118,18 @@ export function BoardSkillElement({
                 <div className="flex gap-2">
                   <Select
                     onValueChange={(value: Tier) => {
+                      const actualIndex = gameState.players[
+                        playerID
+                      ].board.findIndex((x) => x.uuid === boardSkill.uuid);
+                      const lastCardIndex = gameState.players[
+                        playerID
+                      ].board.findLastIndex(
+                        (x) => x.card.$type === CardType.TCardItem,
+                      );
+                      const skillIndex = actualIndex - lastCardIndex - 1;
+
                       simulatorStoreActions.setSkillTier(
-                        boardCardID,
+                        skillIndex,
                         value,
                         playerID === ENEMY_PLAYER_IDX,
                       );

--- a/src/components/WinrateCalculator.tsx
+++ b/src/components/WinrateCalculator.tsx
@@ -16,10 +16,10 @@ export default function WinrateCalculator() {
   );
   const steps = useSimulatorStore((state) => state.steps);
   const [simCount, setSimCount] = useState(
-    targetSimulations > 0 ? targetSimulations : 100,
+    targetSimulations > 0 ? targetSimulations : 10,
   );
   const lastCalculatedCountRef = useRef(
-    targetSimulations > 0 ? targetSimulations : 100,
+    targetSimulations > 0 ? targetSimulations : 10,
   );
   const isEnabled = isCalculating || winrate !== null;
 
@@ -34,7 +34,7 @@ export default function WinrateCalculator() {
 
   // Only update the input value, but don't trigger recalculation
   const handleSimCountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = parseInt(e.target.value) || 100;
+    const value = parseInt(e.target.value) || 10;
     setSimCount(value);
   };
 
@@ -67,7 +67,7 @@ export default function WinrateCalculator() {
           <>
             <Input
               type="number"
-              min="10"
+              min="2"
               max="1000"
               value={simCount}
               onChange={handleSimCountChange}

--- a/src/engine/engine2/notes.md
+++ b/src/engine/engine2/notes.md
@@ -20,7 +20,7 @@ Start of fight poison and burn process a tick and apply before the fight starts.
 - [ ] use internal queue not only for multicast, but also for triggers, like "when you slow, deal damage", Proboscis should have an internal cooldown/max fire rate. https://www.howbazaar.gg/items?isShowingAdvancedFilters=true#Proboscis
 - [ ] Fork [BazaarPlannerMod](https://github.com/oceanseth/BazaarPlannerMod) and implement websocket connection to client browser.
 - [ ] Fix last transformation actions. Will have to implement tooltip parsing since the transformation target it server side.
-- [ ] Add support for modifying skill tier
+- [x] Add support for modifying skill tier
 - [x] limit boardcard attribute values to .1 digits
 
 ### BUGS:

--- a/src/lib/simulatorStore.ts
+++ b/src/lib/simulatorStore.ts
@@ -241,7 +241,9 @@ const runSimulationAndUpdateWinrate = () => {
   const state = useSimulatorStore.getState();
   const actions = state.actions;
   // Run the simulation and update steps
-  state.steps = runWrapper(state.enemyConfig, state.playerConfig);
+  useSimulatorStore.setState((state) => {
+    state.steps = runWrapper(state.enemyConfig, state.playerConfig);
+  });
 
   // If winrate calculation is enabled, schedule recalculation after current update completes
   if (


### PR DESCRIPTION
Improves the editing of skill tiers on the board and refactors the winrate calculation process.

- **Skill Tier Editing:**
  - Enables modification of skill tiers directly from the board through a dialog for skill editing.
  - Introduces a `setEditingCardLocation` action in the simulator store to manage the currently edited card's location (board/hand, player index, and card index).

- **Winrate Calculation Refactor:**
  - Updates the `runSimulationAndUpdateWinrate` function to use `setState`, ensuring that state updates are handled correctly.
  - Reduces the default simulation count for winrate calculation from 100 to 10, and updates the minimum input value from "10" to "2".
